### PR TITLE
Version 3.0.0

### DIFF
--- a/.changes/added/7.md
+++ b/.changes/added/7.md
@@ -1,1 +1,0 @@
-Change in the readme to be more explicit

--- a/.changes/breaking/10.md
+++ b/.changes/breaking/10.md
@@ -1,1 +1,0 @@
-Second big breaking on README.md

--- a/.changes/breaking/9.md
+++ b/.changes/breaking/9.md
@@ -1,1 +1,0 @@
-Add a big breaking change that reserve the world in README.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased (see .changes folder)]
 
+
+## [Version 3.0.0]
+
+### Breaking
+- [9](https://github.com/OltaLabs/no-conflict-keep-a-changelog-action/pull/9): Add a big breaking change that reserve the world in README.
+- [10](https://github.com/OltaLabs/no-conflict-keep-a-changelog-action/pull/10): Second big breaking on README.md
+
+### Added
+- [7](https://github.com/OltaLabs/no-conflict-keep-a-changelog-action/pull/7): Change in the readme to be more explicit
+
 ## [Version 2.8.3]
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Test
 Breaking
 BREAKING ENORMOUS
+
+Imagine change version in CARGO.TOML


### PR DESCRIPTION
## Version 3.0.0

### Breaking
- [9](https://github.com/OltaLabs/no-conflict-keep-a-changelog-action/pull/9): Add a big breaking change that reserve the world in README.
- [10](https://github.com/OltaLabs/no-conflict-keep-a-changelog-action/pull/10): Second big breaking on README.md

### Added
- [7](https://github.com/OltaLabs/no-conflict-keep-a-changelog-action/pull/7): Change in the readme to be more explicit
